### PR TITLE
Add grok-4-latest support and set as default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ export XAI_API_KEY="your-api-key-here"
 
 You can now access the Grok model. Run `llm models` to see it in the list.
 
-To run a prompt through `grok-3-latest` (default model):
+To run a prompt through `grok-4-latest` (default model):
 
 ```bash
-llm -m grok-3-latest 'What is the meaning of life, the universe, and everything?'
+llm -m grok-4-latest 'What is the meaning of life, the universe, and everything?'
 ```
 
 To start an interactive chat session:
 
 ```bash
-llm chat -m grok-3-latest
+llm chat -m grok-4-latest
 ```
 
 Example chat session:
 ```
-Chatting with grok-3-latest
+Chatting with grok-4-latest
 Type 'exit' or 'quit' to exit
 Type '!multi' to enter multiple lines, then '!end' to finish
 > Tell me a joke about programming
@@ -55,7 +55,7 @@ Type '!multi' to enter multiple lines, then '!end' to finish
 To use a system prompt to give Grok specific instructions:
 
 ```bash
-cat example.py | llm -m grok-3-latest -s 'explain this code in a humorous way'
+cat example.py | llm -m grok-4-latest -s 'explain this code in a humorous way'
 ```
 
 To set your default model:
@@ -69,7 +69,8 @@ llm models default grok-3-mini-latest
 
 The following Grok models are available:
 
-- `grok-3-latest` (default)
+- `grok-4-latest` (default)
+- `grok-3-latest`
 - `grok-3-mini-fast-latest`
 - `grok-3-mini-latest`
 - `grok-3-fast-latest`
@@ -83,7 +84,7 @@ llm grok models
 
 ## Model Options
 
-The grok-3-latest model accepts the following options, using `-o name value` syntax:
+The grok-4-latest model accepts the following options, using `-o name value` syntax:
 
 * `-o temperature 0.7`: The sampling temperature, between 0 and 1. Higher values like 0.8 increase randomness, while lower values like 0.2 make the output more focused and deterministic.
 * `-o max_completion_tokens 100`: Maximum number of tokens to generate in the completion (includes both visible tokens and reasoning tokens).
@@ -91,7 +92,7 @@ The grok-3-latest model accepts the following options, using `-o name value` syn
 Example with options:
 
 ```bash
-llm -m grok-3-latest -o temperature 0.2 -o max_completion_tokens 50 'Write a haiku about AI'
+llm -m grok-4-latest -o temperature 0.2 -o max_completion_tokens 50 'Write a haiku about AI'
 ```
 
 ## Development

--- a/llm_grok.py
+++ b/llm_grok.py
@@ -15,6 +15,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 console = Console()
 
 AVAILABLE_MODELS = [
+    "grok-4-latest",
     "grok-3-latest",
     "grok-3-fast-latest",
     "grok-3-mini-latest",
@@ -22,7 +23,7 @@ AVAILABLE_MODELS = [
     "grok-2-latest",
     "grok-2-vision-latest",
 ]
-DEFAULT_MODEL = "grok-3-latest"
+DEFAULT_MODEL = "grok-4-latest"
 
 
 @llm.hookimpl

--- a/tests/test_grok.py
+++ b/tests/test_grok.py
@@ -30,7 +30,7 @@ def model():
 def mock_env(monkeypatch):
     """Mock environment variables and API key for testing"""
     monkeypatch.setenv("XAI_API_KEY", "xai-test-key-mock")
-    monkeypatch.setattr(llm.Model, "get_key", lambda self: "xai-test-key-mock")
+    monkeypatch.setattr("llm_grok.Grok.get_key", lambda self, key=None: "xai-test-key-mock")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds support for grok-4-latest, which xAI recently made available through their API.

Changes:
- Added grok-4-latest to AVAILABLE_MODELS 
- Updated DEFAULT_MODEL to use grok-4 instead of grok-3
- Updated README examples to use the new default

Also fixed an issue where tests were using real API keys from llm's stored configuration instead of the mocked test key. This caused test failures because the mocked HTTP requests expected a different authorization header.

All tests pass. Happy to make any adjustments if needed.